### PR TITLE
Add native init state and null-safe URI handling

### DIFF
--- a/app/src/main/java/moe/ouom/wekit/config/MmkvConfigManagerImpl.java
+++ b/app/src/main/java/moe/ouom/wekit/config/MmkvConfigManagerImpl.java
@@ -368,6 +368,7 @@ public class MmkvConfigManagerImpl extends WeConfig {
 
     protected MmkvConfigManagerImpl(@NonNull String name) {
         mmkvId = Objects.requireNonNull(name, "name");
+        // 调用前需要等待模块mmkv初始化完毕
         mmkv = MMKV.mmkvWithID(name, MMKV.MULTI_PROCESS_MODE);
         file = new File(MMKV.getRootDir(), name);
     }

--- a/app/src/main/java/moe/ouom/wekit/hooks/sdk/protocol/listener/WePkgDispatcher.kt
+++ b/app/src/main/java/moe/ouom/wekit/hooks/sdk/protocol/listener/WePkgDispatcher.kt
@@ -32,7 +32,8 @@ class WePkgDispatcher : ApiHookItem(), IDexFind {
                 val v0Var = param.args[1] ?: return@hookBefore
                 val originalCallback = param.args[2] ?: return@hookBefore
 
-                val uri = XposedHelpers.callMethod(v0Var, "getUri") as String
+                // 有时 getUri 返回 null
+                val uri = (XposedHelpers.callMethod(v0Var, "getUri") ?: "null") as String
                 val cgiId = XposedHelpers.callMethod(v0Var, "getType") as Int
                 try {
                     val reqWrapper = XposedHelpers.callMethod(v0Var, "getReqObj")

--- a/app/src/main/java/moe/ouom/wekit/util/log/LogUtils.java
+++ b/app/src/main/java/moe/ouom/wekit/util/log/LogUtils.java
@@ -10,6 +10,7 @@ import java.util.Calendar;
 
 import de.robv.android.xposed.XposedBridge;
 import moe.ouom.wekit.config.WeConfig;
+import moe.ouom.wekit.loader.core.NativeCoreBridge;
 import moe.ouom.wekit.util.io.FileUtils;
 import moe.ouom.wekit.util.io.PathTool;
 
@@ -99,7 +100,7 @@ public class LogUtils {
 
     private static void addLog(String fileName, String Description, Object content, boolean isError) {
         try {
-            if (!WeConfig.getDefaultConfig().getBooleanOrFalse(PrekEnableLog)){
+            if (NativeCoreBridge.isNativeCoreInitialized() && !WeConfig.getDefaultConfig().getBooleanOrFalse(PrekEnableLog)){
                 return;
             }
         } catch (Exception e) {


### PR DESCRIPTION
## 描述 / Description
修复当模块mmkv未初始化时调用WeLogger类可能报错的问题 修复有时getUri返回null报错的问题

## 类型 / Type

- [x] Bug 修复 / Bug Fix  
- [ ] 新功能 / New Feature  
- [ ] 文档更新 / Documentation Update  
- [ ] 其他（请描述）/ Other (please describe):  

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 清单 / Checklist

- [x] 我已阅读并遵循贡献指南 / I have read and followed the contribution guidelines
- [x] 我已在本地测试这些更改 / I have tested these changes locally
- [x] 我已更新相关文档或注释（如适用） / I have updated relevant documentation or comments (if applicable)
- [x] **我确认此更改不会破坏任何原有功能** / I confirm this change does not break any existing features
- [x] **我已进行多版本适配（如适用）** / I have used MMVersion for version compatibility (if applicable)
- [x] **我已在多个微信版本上测试此更改（如适用）** / I have tested this change on multiple WeChat versions (if applicable)  

## 其他信息 / Additional Information

<!--- 请在此补充任何与审查相关的额外信息或截图 / Please add any extra details or screenshots related to the review here.  -->